### PR TITLE
Handle resource naming with greater specificity

### DIFF
--- a/infra/core/host/functions.bicep
+++ b/infra/core/host/functions.bicep
@@ -31,6 +31,7 @@ param minimumElasticInstanceCount int = -1
 param numberOfWorkers int = -1
 param healthCheckPath string = ''
 param storageAccountName string
+param blobContainerName string
 
 resource appService 'Microsoft.Web/sites@2023-12-01' = {
   name: name
@@ -54,7 +55,7 @@ resource appService 'Microsoft.Web/sites@2023-12-01' = {
       deployment: {
         storage: {
           type: 'blobContainer'
-          value: '${storage.properties.primaryEndpoints.blob}${name}'
+          value: '${storage.properties.primaryEndpoints.blob}${blobContainerName}'
           authentication: {
             type: 'SystemAssignedIdentity'
           }


### PR DESCRIPTION
Fixes #77.

This PR creates derives names for a few different resources in ways that better align with the naming requirements specific to each resource. As a result, a deployment is less likely to fail, and multiple deployments are less likely to have a naming collision